### PR TITLE
Improve gemspec URLs

### DIFF
--- a/holiday_japan.gemspec
+++ b/holiday_japan.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["masa16.tanaka@gmail.com"]
   gem.summary       = %q{Calculate National Holidays of Japan}
   gem.description   = %q{Calculate National Holidays of Japan after 1948}
-  gem.homepage      = "http://masa16.github.io/holiday_japan/"
+  gem.homepage      = "https://masa16.github.io/holiday_japan/"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)

--- a/holiday_japan.gemspec
+++ b/holiday_japan.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://masa16.github.io/holiday_japan/"
   gem.license       = "MIT"
 
+  gem.metadata['source_code_uri'] = 'https://github.com/masa16/holiday_japan'
+
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
祝日の確認のために、ありがたくholiday_japan gemを使わせてもらっています。

gemspecに2点ほど改善できそうなところを見つけたので、Pull Requestを送ることにしました。

## homepage

GitHub Pagesで提供されているGemのホームページへのURLがHTTPになっていたので、HTTPSに変更しました。

いまの設定だとGitHub PagesはHTTP版からHTTPS版へのリダイレクトを行ってくれないし、またどのみち無駄なリダイレクトも避けたいということで、HTTPS版を記載した方が良いなと考えました。

![image](https://user-images.githubusercontent.com/111689/175792510-853a3190-c0e0-45c4-8865-13caa645479e.png)

この情報は、上のリンクで使われたり、他にgemspecやrubygems.orgを扱うツールなどで利用されることがあります。

![image](https://user-images.githubusercontent.com/111689/175792604-77cdd430-d1ca-4cd9-9145-0b7dc5290ce4.png)

上の部分にもHTTP版のリンクが記載されていて、これは別途手作業で変える必要がありそうです。

## source_code_uri

リポジトリのURLを、ソースコードのURLとして追加しました。

最近では `bundle gem` の雛形でもこのようなメタデータがデフォルトで追加されることもあるし、あった方が良いかなと思います。実際、自分はgemspecのこの情報を元に依存Gemの変更確認を支援するツールを使っており、holiday_japan gemもgemspecにソースコードのURLを書いていてくれたらいいのにな、と思うことがありました。

昔はrubygems.orgのサイト上でこれを編集できたようで、上のスクリーンショットでもわかる通りサイト上ではソースコードへのリンクが貼られていますね。いまではこの機能は廃止されて編集できなくなってしまったようなので、gemspecに記載するのが良いかなと思っています。